### PR TITLE
feat : 주문 CRUD api 구현 및 단위 테스트 코드 작성

### DIFF
--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/OrderController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/OrderController.java
@@ -1,13 +1,17 @@
 package com.sparta.blackwhitedeliverydriver.controller;
 
+import com.sparta.blackwhitedeliverydriver.dto.OrderGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
 import com.sparta.blackwhitedeliverydriver.security.UserDetailsImpl;
 import com.sparta.blackwhitedeliverydriver.service.OrderService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,5 +30,15 @@ public class OrderController {
         OrderResponseDto response = orderService.createOrder(userDetails.getUsername());
         //201 반환
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Secured({"ROLE_CUSTOMER", "ROLE_MASTER", "ROLE_MANAGER"})
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderGetResponseDto> getOrderDetail(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                              @PathVariable UUID orderId) {
+        //주문서 상세 조회
+        OrderGetResponseDto response = orderService.getOrderDetail(userDetails.getUsername(), orderId);
+        //200 반환
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/OrderController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/OrderController.java
@@ -4,6 +4,7 @@ import com.sparta.blackwhitedeliverydriver.dto.OrderGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
 import com.sparta.blackwhitedeliverydriver.security.UserDetailsImpl;
 import com.sparta.blackwhitedeliverydriver.service.OrderService;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -40,5 +41,14 @@ public class OrderController {
         OrderGetResponseDto response = orderService.getOrderDetail(userDetails.getUsername(), orderId);
         //200 반환
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Secured({"ROLE_CUSTOMER", "ROLE_MASTER", "ROLE_MANAGER"})
+    @GetMapping
+    public ResponseEntity<List<OrderGetResponseDto>> getOrders(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        //주문 목록 조회
+        List<OrderGetResponseDto> responseList = orderService.getOrders(userDetails.getUsername());
+        //200 반환
+        return ResponseEntity.status(HttpStatus.OK).body(responseList);
     }
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/OrderController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/OrderController.java
@@ -2,6 +2,8 @@ package com.sparta.blackwhitedeliverydriver.controller;
 
 import com.sparta.blackwhitedeliverydriver.dto.OrderGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
+import com.sparta.blackwhitedeliverydriver.dto.OrderUpdateRequestDto;
+import com.sparta.blackwhitedeliverydriver.entity.User;
 import com.sparta.blackwhitedeliverydriver.security.UserDetailsImpl;
 import com.sparta.blackwhitedeliverydriver.service.OrderService;
 import java.util.List;
@@ -14,6 +16,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -50,5 +54,15 @@ public class OrderController {
         List<OrderGetResponseDto> responseList = orderService.getOrders(userDetails.getUsername());
         //200 반환
         return ResponseEntity.status(HttpStatus.OK).body(responseList);
+    }
+
+    @Secured({"ROLE_OWNER"})
+    @PutMapping
+    public ResponseEntity<OrderResponseDto> updateOrderStatus(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                              @RequestBody OrderUpdateRequestDto request) {
+        //주문 상태 변경
+        OrderResponseDto response = orderService.updateOrderStatus(userDetails.getUsername(), request);
+        //200 반환
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/OrderController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/OrderController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -62,6 +63,16 @@ public class OrderController {
                                                               @RequestBody OrderUpdateRequestDto request) {
         //주문 상태 변경
         OrderResponseDto response = orderService.updateOrderStatus(userDetails.getUsername(), request);
+        //200 반환
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Secured({"ROLE_CUSTOMER"})
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<OrderResponseDto> deleteOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                        @PathVariable UUID orderId){
+        //주문 취소
+        OrderResponseDto response = orderService.deleteOrder(userDetails.getUsername(), orderId);
         //200 반환
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/OrderGetResponseDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/OrderGetResponseDto.java
@@ -1,6 +1,7 @@
 package com.sparta.blackwhitedeliverydriver.dto;
 
 import com.sparta.blackwhitedeliverydriver.entity.Order;
+import com.sparta.blackwhitedeliverydriver.entity.OrderStatusEnum;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,15 +14,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class OrderGetResponseDto {
     private UUID orderId;
+    private UUID storeId;
     private String username;
+    private OrderStatusEnum status;
     private Integer finalPay;
     private Integer discountRate;
     private Integer discountAmount;
 
-    public static OrderGetResponseDto fromOrder(Order order){
+    public static OrderGetResponseDto fromOrder(Order order) {
         return OrderGetResponseDto.builder()
                 .orderId(order.getId())
+                .storeId(order.getStore())
                 .username(order.getUser().getUsername())
+                .status(order.getStatus())
                 .finalPay(order.getFinalPay())
                 .discountRate(order.getDiscountRate())
                 .discountAmount(order.getDiscountAmount())

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/OrderGetResponseDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/OrderGetResponseDto.java
@@ -1,0 +1,30 @@
+package com.sparta.blackwhitedeliverydriver.dto;
+
+import com.sparta.blackwhitedeliverydriver.entity.Order;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderGetResponseDto {
+    private UUID orderId;
+    private String username;
+    private Integer finalPay;
+    private Integer discountRate;
+    private Integer discountAmount;
+
+    public static OrderGetResponseDto fromOrder(Order order){
+        return OrderGetResponseDto.builder()
+                .orderId(order.getId())
+                .username(order.getUser().getUsername())
+                .finalPay(order.getFinalPay())
+                .discountRate(order.getDiscountRate())
+                .discountAmount(order.getDiscountAmount())
+                .build();
+    }
+}

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/OrderResponseDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/OrderResponseDto.java
@@ -7,16 +7,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter
-@Builder
 public class OrderResponseDto {
     private UUID orderId;
-
-    public static OrderResponseDto from(Order order) {
-        return OrderResponseDto.builder()
-                .orderId(order.getId())
-                .build();
-    }
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/OrderUpdateRequestDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/OrderUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.sparta.blackwhitedeliverydriver.dto;
+
+import com.sparta.blackwhitedeliverydriver.entity.OrderStatusEnum;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderUpdateRequestDto {
+    @NotNull
+    private UUID orderId;
+    @NotNull
+    private OrderStatusEnum status;
+}

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/Basket.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/Basket.java
@@ -36,6 +36,14 @@ public class Basket extends BaseEntity {
     @Column(nullable = false)
     private Integer quantity;
 
+    public static Basket ofUserAndOrderProduct(User user, OrderProduct orderProduct) {
+        return Basket.builder()
+                .productId(orderProduct.getProduct())
+                .quantity(orderProduct.getQuantity())
+                .user(user)
+                .build();
+    }
+
     public void updateBasketOfQuantity(Integer quantity) {
         this.quantity = quantity;
     }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/Order.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/Order.java
@@ -2,6 +2,8 @@ package com.sparta.blackwhitedeliverydriver.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,6 +35,9 @@ public class Order extends BaseEntity {
     private User user;
 
     @Column(nullable = false)
+    private UUID store; //임시 컬럼
+
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Integer finalPay;
 
@@ -42,16 +47,26 @@ public class Order extends BaseEntity {
     @Column(nullable = false)
     private Integer discountAmount;
 
-    public static Order fromUser(User user) {
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private OrderStatusEnum status;
+
+    public static Order fromUser(User user, UUID store) {
         return Order.builder()
                 .user(user)
+                .store(store)
                 .finalPay(0)
                 .discountAmount(0)
                 .discountRate(0)
+                .status(OrderStatusEnum.CREATE)
                 .build();
     }
 
     public void updateFinalPay(int price) {
         this.finalPay = price;
+    }
+
+    public void updateStatus(OrderStatusEnum status) {
+        this.status = status;
     }
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/OrderStatusEnum.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/OrderStatusEnum.java
@@ -1,0 +1,26 @@
+package com.sparta.blackwhitedeliverydriver.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum OrderStatusEnum {
+    CREATE,         // 주문 생성 상태
+    PENDING,       // 주문 대기 상태
+    ACCEPTED,     // 주문 수락 상태
+    REJECTED,     // 주문 거절 상태
+    COMPLETED;   // 주문 완료 상태
+
+    public String getStatus() {
+        return this.name();
+    }
+
+    @JsonCreator
+    public static OrderStatusEnum fromString(String status) {
+        return OrderStatusEnum.valueOf(status.toUpperCase()); // 대소문자 구분하지 않음
+    }
+
+    @JsonValue
+    public String toValue() {
+        return this.name(); // name()은 enum의 이름을 반환 (PENDING, ACCEPTED 등)
+    }
+}

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/OrderExceptionMessage.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/OrderExceptionMessage.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OrderExceptionMessage {
     ORDER_NOT_FOUND("주문 내역을 찾을 수 없습니다."),
-    ORDER_USER_NOT_EQUALS("주문서의 유저가 아닙니다.") ;
+    ORDER_USER_NOT_EQUALS("주문서의 유저가 아닙니다."),
+    ORDER_UNABLE_DELETE_STATUS("주문을 취소할 수 있는 상태가 아닙니다.");
     private final String message;
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/OrderExceptionMessage.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/OrderExceptionMessage.java
@@ -1,0 +1,12 @@
+package com.sparta.blackwhitedeliverydriver.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderExceptionMessage {
+    ORDER_NOT_FOUND("주문 내역을 찾을 수 없습니다."),
+    ORDER_USER_NOT_EQUALS("주문서의 유저가 아닙니다.") ;
+    private final String message;
+}

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/OrderProductRepository.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/OrderProductRepository.java
@@ -1,8 +1,11 @@
 package com.sparta.blackwhitedeliverydriver.repository;
 
+import com.sparta.blackwhitedeliverydriver.entity.Order;
 import com.sparta.blackwhitedeliverydriver.entity.OrderProduct;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderProductRepository extends JpaRepository<OrderProduct, UUID> {
+    List<OrderProduct> findAllByOrder(Order order);
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/OrderRepository.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/OrderRepository.java
@@ -1,8 +1,11 @@
 package com.sparta.blackwhitedeliverydriver.repository;
 
 import com.sparta.blackwhitedeliverydriver.entity.Order;
+import com.sparta.blackwhitedeliverydriver.entity.User;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
+    List<Order> findAllByUser(User user);
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
@@ -1,18 +1,22 @@
 package com.sparta.blackwhitedeliverydriver.service;
 
+import com.sparta.blackwhitedeliverydriver.dto.OrderGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
 import com.sparta.blackwhitedeliverydriver.entity.Basket;
 import com.sparta.blackwhitedeliverydriver.entity.Order;
 import com.sparta.blackwhitedeliverydriver.entity.OrderProduct;
 import com.sparta.blackwhitedeliverydriver.entity.User;
+import com.sparta.blackwhitedeliverydriver.entity.UserRoleEnum;
 import com.sparta.blackwhitedeliverydriver.exception.BasketExceptionMessage;
 import com.sparta.blackwhitedeliverydriver.exception.ExceptionMessage;
+import com.sparta.blackwhitedeliverydriver.exception.OrderExceptionMessage;
 import com.sparta.blackwhitedeliverydriver.repository.BasketRepository;
 import com.sparta.blackwhitedeliverydriver.repository.OrderProductRepository;
 import com.sparta.blackwhitedeliverydriver.repository.OrderRepository;
 import com.sparta.blackwhitedeliverydriver.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,13 +36,17 @@ public class OrderService {
         //유저 유효성 검사
         User user = userRepository.findById(username)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         //유저와 관련된 장바구니 품목 찾기
         List<Basket> baskets = basketRepository.findAllByUser(user);
+
         //장바구니 개수 체크
         checkBasketCount(baskets);
+
         //order 엔티티 생성 및 저장
         Order order = Order.fromUser(user);
         order = orderRepository.save(order);
+
         //연관관계 테이블에 장바구니 품목 저장
         List<OrderProduct> orderProducts = new ArrayList<>();
         for (Basket basket : baskets) {
@@ -46,14 +54,36 @@ public class OrderService {
             orderProducts.add(orderProduct);
         }
         orderProductRepository.saveAll(orderProducts);
+
         //장바구니 삭제
         basketRepository.deleteAll(baskets);
+
         //최종금액 계산 및 업데이트
         int price = calculateFinalPay(orderProducts);
         order.updateFinalPay(price);
         orderRepository.save(order);
 
         return new OrderResponseDto(order.getId());
+    }
+
+    public OrderGetResponseDto getOrderDetail(String username, UUID orderId) {
+        //유저 유효성
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
+        //주문 유효성
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new NullPointerException(OrderExceptionMessage.ORDER_NOT_FOUND.getMessage()));
+
+        // CUSTOMER인 경우 Order의 user인지 체크
+        if (user.getRole().equals(UserRoleEnum.CUSTOMER)) {
+            checkOrderUser(order, user);
+        }
+
+        // Product Entity 구현되면 음식 목록도 포함하여 리턴
+        // code..
+
+        return OrderGetResponseDto.fromOrder(order);
     }
 
     private void checkBasketCount(List<Basket> baskets) {
@@ -67,4 +97,13 @@ public class OrderService {
                 .mapToInt(orderProduct -> orderProduct.getPrice() * orderProduct.getQuantity())
                 .sum();
     }
+
+    private void checkOrderUser(Order order, User user) {
+        String orderUsername = order.getUser().getUsername();
+        String username = user.getUsername();
+        if (!orderUsername.equals(username)) {
+            throw new IllegalArgumentException(OrderExceptionMessage.ORDER_USER_NOT_EQUALS.getMessage());
+        }
+    }
+
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
@@ -17,6 +17,7 @@ import com.sparta.blackwhitedeliverydriver.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,6 +87,22 @@ public class OrderService {
         return OrderGetResponseDto.fromOrder(order);
     }
 
+    public List<OrderGetResponseDto> getOrders(String username) {
+        //유저 유효성
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
+        //주문 조회
+        List<Order> orders;
+        if (user.getRole().equals(UserRoleEnum.CUSTOMER)) {
+            orders = orderRepository.findAllByUser(user);
+        } else {
+            orders = orderRepository.findAll();
+        }
+
+        return orders.stream().map(OrderGetResponseDto::fromOrder).collect(Collectors.toList());
+    }
+
     private void checkBasketCount(List<Basket> baskets) {
         if (baskets.isEmpty()) {
             throw new IllegalArgumentException(BasketExceptionMessage.BASKET_COUNT_ZERO.getMessage());
@@ -105,5 +122,4 @@ public class OrderService {
             throw new IllegalArgumentException(OrderExceptionMessage.ORDER_USER_NOT_EQUALS.getMessage());
         }
     }
-
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
@@ -93,6 +93,7 @@ public class OrderService {
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
 
         //주문 조회
+        //점포 주인 권한은 Product 엔티티가 생성된 후 추가하겠습니다.
         List<Order> orders;
         if (user.getRole().equals(UserRoleEnum.CUSTOMER)) {
             orders = orderRepository.findAllByUser(user);

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
@@ -28,7 +28,7 @@ public class OrderService {
     private final UserRepository userRepository;
 
     @Transactional
-    public OrderResponseDto createOrder(String username) { // 메서드를 어떻게 개선할 수 있을까요...? 좋은 의견 남겨주시면 감사하겠습니다...
+    public OrderResponseDto createOrder(String username) {
         //유저 유효성 검사
         User user = userRepository.findById(username)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
@@ -53,7 +53,7 @@ public class OrderService {
         order.updateFinalPay(price);
         orderRepository.save(order);
 
-        return OrderResponseDto.from(order);
+        return new OrderResponseDto(order.getId());
     }
 
     private void checkBasketCount(List<Basket> baskets) {

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
@@ -2,6 +2,7 @@ package com.sparta.blackwhitedeliverydriver.service;
 
 import com.sparta.blackwhitedeliverydriver.dto.OrderGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
+import com.sparta.blackwhitedeliverydriver.dto.OrderUpdateRequestDto;
 import com.sparta.blackwhitedeliverydriver.entity.Basket;
 import com.sparta.blackwhitedeliverydriver.entity.Order;
 import com.sparta.blackwhitedeliverydriver.entity.OrderProduct;
@@ -14,6 +15,7 @@ import com.sparta.blackwhitedeliverydriver.repository.BasketRepository;
 import com.sparta.blackwhitedeliverydriver.repository.OrderProductRepository;
 import com.sparta.blackwhitedeliverydriver.repository.OrderRepository;
 import com.sparta.blackwhitedeliverydriver.repository.UserRepository;
+import jakarta.validation.constraints.Null;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -45,7 +47,8 @@ public class OrderService {
         checkBasketCount(baskets);
 
         //order 엔티티 생성 및 저장
-        Order order = Order.fromUser(user);
+        UUID storeId = UUID.randomUUID();
+        Order order = Order.fromUser(user, storeId);
         order = orderRepository.save(order);
 
         //연관관계 테이블에 장바구니 품목 저장
@@ -122,5 +125,18 @@ public class OrderService {
         if (!orderUsername.equals(username)) {
             throw new IllegalArgumentException(OrderExceptionMessage.ORDER_USER_NOT_EQUALS.getMessage());
         }
+    }
+
+    public OrderResponseDto updateOrderStatus(String username, OrderUpdateRequestDto request) {
+        //유저 유효성
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+        //주문 유효성
+        Order order = orderRepository.findById(request.getOrderId())
+                .orElseThrow(() -> new NullPointerException(OrderExceptionMessage.ORDER_NOT_FOUND.getMessage()));
+        //주문의 점포 주인과 유저 체크
+        //Code...
+        order.updateStatus(request.getStatus());
+        return new OrderResponseDto(order.getId());
     }
 }

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
@@ -3,6 +3,7 @@ package com.sparta.blackwhitedeliverydriver.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -131,5 +132,24 @@ class OrderControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.orderId").exists());
 
+    }
+
+    @Test
+    @DisplayName("주문 취소하기")
+    @MockUser(role = UserRoleEnum.CUSTOMER)
+    void deleteOrder() throws Exception {
+        //given
+        String username = "user";
+        UUID orderId = UUID.randomUUID();
+        OrderResponseDto response = new OrderResponseDto(orderId);
+
+        //when
+        when(orderService.deleteOrder(any(), any())).thenReturn(response);
+
+        //then
+        mvc.perform(delete(BASE_URL + "/orders/{orderId}", orderId.toString())
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.orderId").exists());
     }
 }

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
@@ -5,12 +5,15 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.blackwhitedeliverydriver.dto.OrderGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
+import com.sparta.blackwhitedeliverydriver.dto.OrderUpdateRequestDto;
+import com.sparta.blackwhitedeliverydriver.entity.OrderStatusEnum;
 import com.sparta.blackwhitedeliverydriver.entity.UserRoleEnum;
 import com.sparta.blackwhitedeliverydriver.mock.user.MockUser;
 import com.sparta.blackwhitedeliverydriver.service.OrderService;
@@ -21,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(OrderController.class)
@@ -102,6 +106,30 @@ class OrderControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*.orderId").exists())
                 .andExpect(jsonPath("$.*.username").exists());
+
+    }
+
+    @Test
+    @DisplayName("주문 상태 수정하기")
+    @MockUser(role = UserRoleEnum.OWNER)
+    void updateOrderStatus() throws Exception {
+        //given
+        UUID orderId = UUID.randomUUID();
+        OrderUpdateRequestDto request = new OrderUpdateRequestDto(orderId, OrderStatusEnum.ACCEPTED);
+        OrderResponseDto response = new OrderResponseDto(orderId);
+
+        //when
+        when(orderService.updateOrderStatus(any(), any())).thenReturn(response);
+
+        //then
+        String body = mapper.writeValueAsString(request);
+
+        mvc.perform(put(BASE_URL + "/orders")
+                        .with(csrf())
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.orderId").exists());
 
     }
 }

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
@@ -38,9 +38,7 @@ class OrderControllerTest {
     void createOrder() throws Exception {
         //given
         String orderId = "3e678a43-41b1-4a35-97fb-4ad686308074";
-        OrderResponseDto response = OrderResponseDto.builder()
-                .orderId(UUID.fromString(orderId))
-                .build();
+        OrderResponseDto response = new OrderResponseDto(UUID.fromString(orderId));
         //when
         when(orderService.createOrder(any())).thenReturn(response);
         //then

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
@@ -3,12 +3,15 @@ package com.sparta.blackwhitedeliverydriver.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.blackwhitedeliverydriver.dto.OrderGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
+import com.sparta.blackwhitedeliverydriver.entity.UserRoleEnum;
 import com.sparta.blackwhitedeliverydriver.mock.user.MockUser;
 import com.sparta.blackwhitedeliverydriver.service.OrderService;
 import java.util.UUID;
@@ -33,7 +36,7 @@ class OrderControllerTest {
     private static final String BASE_URL = "/api/v1";
 
     @Test
-    @DisplayName("주문생성하기")
+    @DisplayName("주문 생성하기")
     @MockUser
     void createOrder() throws Exception {
         //given
@@ -47,5 +50,30 @@ class OrderControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.orderId").exists());
 
+    }
+
+    @Test
+    @DisplayName("관리자용 주문 상세 조회하기")
+    @MockUser(role = UserRoleEnum.MASTER)
+    void getOrderDetail() throws Exception {
+        //given
+        String orderId = "3e678a43-41b1-4a35-97fb-4ad686308074";
+        String username = "user1";
+        OrderGetResponseDto response = OrderGetResponseDto.builder()
+                .orderId(UUID.fromString(orderId))
+                .username(username)
+                .finalPay(10000)
+                .discountAmount(0)
+                .discountRate(0)
+                .build();
+
+        //when
+        when(orderService.getOrderDetail(any(), any())).thenReturn(response);
+
+        //then
+        mvc.perform(get(BASE_URL + "/orders/admin/{orderId}", orderId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.orderId").exists())
+                .andExpect(jsonPath("$.username").exists());
     }
 }

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/OrderControllerTest.java
@@ -14,6 +14,7 @@ import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
 import com.sparta.blackwhitedeliverydriver.entity.UserRoleEnum;
 import com.sparta.blackwhitedeliverydriver.mock.user.MockUser;
 import com.sparta.blackwhitedeliverydriver.service.OrderService;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,7 @@ class OrderControllerTest {
     }
 
     @Test
-    @DisplayName("관리자용 주문 상세 조회하기")
+    @DisplayName("주문 상세 조회하기")
     @MockUser(role = UserRoleEnum.MASTER)
     void getOrderDetail() throws Exception {
         //given
@@ -71,9 +72,36 @@ class OrderControllerTest {
         when(orderService.getOrderDetail(any(), any())).thenReturn(response);
 
         //then
-        mvc.perform(get(BASE_URL + "/orders/admin/{orderId}", orderId))
+        mvc.perform(get(BASE_URL + "/orders/{orderId}", orderId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.orderId").exists())
                 .andExpect(jsonPath("$.username").exists());
+    }
+
+    @Test
+    @DisplayName("주문 목록 조회하기")
+    @MockUser
+    void getOrders() throws Exception {
+        //given
+        String orderId = "3e678a43-41b1-4a35-97fb-4ad686308074";
+        String username = "user1";
+        OrderGetResponseDto response = OrderGetResponseDto.builder()
+                .orderId(UUID.fromString(orderId))
+                .username(username)
+                .finalPay(10000)
+                .discountAmount(0)
+                .discountRate(0)
+                .build();
+        List<OrderGetResponseDto> responseList = List.of(response);
+
+        //when
+        when(orderService.getOrders(any())).thenReturn(responseList);
+
+        //then
+        mvc.perform(get(BASE_URL + "/orders"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*.orderId").exists())
+                .andExpect(jsonPath("$.*.username").exists());
+
     }
 }

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/dto/OrderUpdateRequestDtoTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/dto/OrderUpdateRequestDtoTest.java
@@ -1,0 +1,52 @@
+package com.sparta.blackwhitedeliverydriver.dto;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.sparta.blackwhitedeliverydriver.entity.OrderStatusEnum;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OrderUpdateRequestDtoTest {
+
+
+    private Validator validator;
+
+    @BeforeEach
+    public void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    @DisplayName("orderId가 null인 경우")
+    public void testOrderIdNotNull() {
+        OrderUpdateRequestDto request = new OrderUpdateRequestDto(null, OrderStatusEnum.PENDING);
+
+        Set<ConstraintViolation<OrderUpdateRequestDto>> violations = validator.validate(request);
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("status가 null인 경우")
+    public void testStatusNotNull() {
+        OrderUpdateRequestDto request = new OrderUpdateRequestDto(UUID.randomUUID(), null);
+
+        Set<ConstraintViolation<OrderUpdateRequestDto>> violations = validator.validate(request);
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("모든 필드가 유효한 경우")
+    public void testValidOrderUpdateRequestDto() {
+        OrderUpdateRequestDto request = new OrderUpdateRequestDto(UUID.randomUUID(), OrderStatusEnum.ACCEPTED);
+
+        Set<ConstraintViolation<OrderUpdateRequestDto>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+}

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/OrderServiceTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/OrderServiceTest.java
@@ -122,7 +122,7 @@ class OrderServiceTest {
 
     @Test
     @DisplayName("주문 상세 조회 성공")
-    void getOrderDetail() {
+    void getOrderDetail_success() {
         //given
         UUID orderId = UUID.fromString("2b6ad274-8f98-44c2-9321-ea0de46b3ec6");
         String username = "user1";
@@ -218,6 +218,51 @@ class OrderServiceTest {
                 () -> orderService.getOrderDetail(username, orderId));
 
         assertEquals(OrderExceptionMessage.ORDER_USER_NOT_EQUALS.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("주문 목록 조회 성공")
+    void getOrders_success() {
+        //given
+        UUID orderId = UUID.fromString("2b6ad274-8f98-44c2-9321-ea0de46b3ec6");
+        String username = "user1";
+        User user = User.builder()
+                .username(username)
+                .role(UserRoleEnum.CUSTOMER)
+                .build();
+        Order order = Order.builder()
+                .id(orderId)
+                .user(user)
+                .discountAmount(0)
+                .discountRate(0)
+                .finalPay(10000)
+                .build();
+
+
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+        when(orderRepository.findAllByUser(any())).thenReturn(List.of(order));
+
+        //when
+        List<OrderGetResponseDto> responseList = orderService.getOrders(username);
+
+        //then
+        assertEquals(username, responseList.get(0).getUsername());
+        assertEquals(orderId, responseList.get(0).getOrderId());
+        assertEquals(order.getFinalPay(), responseList.get(0).getFinalPay());
+    }
+    @Test
+    @DisplayName("주문 목록 조회 실패 : 유저가 존재하지 않는 경우")
+    void getOrders_fail() {
+        //given
+        String username = "user1";
+
+        when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+        //when & then
+        Exception exception = assertThrows(NullPointerException.class,
+                () -> orderService.getOrders(username));
+
+        assertEquals(ExceptionMessage.USER_NOT_FOUND.getMessage(), exception.getMessage());
     }
 
 }

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/OrderServiceTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/OrderServiceTest.java
@@ -1,5 +1,6 @@
 package com.sparta.blackwhitedeliverydriver.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -7,12 +8,15 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.sparta.blackwhitedeliverydriver.dto.OrderGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.OrderResponseDto;
 import com.sparta.blackwhitedeliverydriver.entity.Basket;
 import com.sparta.blackwhitedeliverydriver.entity.Order;
 import com.sparta.blackwhitedeliverydriver.entity.OrderProduct;
 import com.sparta.blackwhitedeliverydriver.entity.User;
 import com.sparta.blackwhitedeliverydriver.entity.UserRoleEnum;
+import com.sparta.blackwhitedeliverydriver.exception.ExceptionMessage;
+import com.sparta.blackwhitedeliverydriver.exception.OrderExceptionMessage;
 import com.sparta.blackwhitedeliverydriver.repository.BasketRepository;
 import com.sparta.blackwhitedeliverydriver.repository.OrderProductRepository;
 import com.sparta.blackwhitedeliverydriver.repository.OrderRepository;
@@ -115,4 +119,105 @@ class OrderServiceTest {
         //when & then
         assertThrows(IllegalArgumentException.class, () -> orderService.createOrder(username));
     }
+
+    @Test
+    @DisplayName("주문 상세 조회 성공")
+    void getOrderDetail() {
+        //given
+        UUID orderId = UUID.fromString("2b6ad274-8f98-44c2-9321-ea0de46b3ec6");
+        String username = "user1";
+        User user = User.builder()
+                .username(username)
+                .role(UserRoleEnum.CUSTOMER)
+                .build();
+        Order order = Order.builder()
+                .id(orderId)
+                .user(user)
+                .discountAmount(0)
+                .discountRate(0)
+                .finalPay(10000)
+                .build();
+
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+        given(orderRepository.findById(any())).willReturn(Optional.ofNullable(order));
+
+        //when
+        OrderGetResponseDto response = orderService.getOrderDetail(username, orderId);
+
+        //then
+        assertEquals(username, response.getUsername());
+        assertEquals(orderId, response.getOrderId());
+        assertEquals(order.getFinalPay(), response.getFinalPay());
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 실패1 : 유저가 없는 경우")
+    void getOrderDetail_fail1() {
+        //given
+        UUID orderId = UUID.fromString("2b6ad274-8f98-44c2-9321-ea0de46b3ec6");
+        String username = "user1";
+
+        when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+        //when & then
+        Exception exception = assertThrows(NullPointerException.class,
+                () -> orderService.getOrderDetail(username, orderId));
+        assertEquals(ExceptionMessage.USER_NOT_FOUND.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 실패2 : 주문서가 없는 경우")
+    void getOrderDetail_fail2() {
+        //given
+        UUID orderId = UUID.fromString("2b6ad274-8f98-44c2-9321-ea0de46b3ec6");
+        String username = "user1";
+        User user = User.builder()
+                .username(username)
+                .role(UserRoleEnum.CUSTOMER)
+                .build();
+
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+
+        when(orderRepository.findById(any())).thenReturn(Optional.empty());
+
+        // when & then
+        Exception exception = assertThrows(NullPointerException.class,
+                () -> orderService.getOrderDetail(username, orderId));
+
+        assertEquals(OrderExceptionMessage.ORDER_NOT_FOUND.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 실패3 : 권한은 CUSTOMER이지만 자신의 주문서가 아닌 경우")
+    void getOrderDetail_fail3() {
+        //given
+        UUID orderId = UUID.fromString("2b6ad274-8f98-44c2-9321-ea0de46b3ec6");
+        String username = "user1";
+        String username2 = "user2";
+        User user = User.builder()
+                .username(username)
+                .role(UserRoleEnum.CUSTOMER)
+                .build();
+        User user2 = User.builder()
+                .username(username2)
+                .role(UserRoleEnum.CUSTOMER)
+                .build();
+        Order order = Order.builder()
+                .id(orderId)
+                .user(user)
+                .discountAmount(0)
+                .discountRate(0)
+                .finalPay(10000)
+                .build();
+
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(user2));
+        given(orderRepository.findById(any())).willReturn(Optional.ofNullable(order));
+
+        // when & then
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> orderService.getOrderDetail(username, orderId));
+
+        assertEquals(OrderExceptionMessage.ORDER_USER_NOT_EQUALS.getMessage(), exception.getMessage());
+    }
+
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/order-api -> main

### 변경 사항
- 주문 crud api 구현 및 테스트 코드 작성
- 권한 별로 다른 사람의 주문서의 접근 권한 처리는 쿼리 param을 사용하지 않고 서비스 레이어에서 처리했습니다.
- order table에 주문 상태를 나타낸 status 컬럼과 store_id를 추가했습니다.