### PR TITLE
refacot : 장바구니, 음식 연동 및 리팩토링

### DIFF
--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/BasketController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/BasketController.java
@@ -10,11 +10,9 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,16 +24,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/baskets")
 @RequiredArgsConstructor
-@Slf4j
+@RequestMapping("/api/v1/baskets")
 public class BasketController {
 
     private final BasketService basketService;
 
     @Secured({"ROLE_CUSTOMER"})
     @PostMapping
-    public ResponseEntity<?> addProductToBasket(@AuthenticationPrincipal UserDetailsImpl userDetails,
+    public ResponseEntity<BasketResponseDto> addProductToBasket(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                 @Valid @RequestBody BasketAddRequestDto request) {
         //장바구니 추가
         BasketResponseDto response = basketService.addProductToBasket(userDetails.getUsername(), request);

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/BasketController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/BasketController.java
@@ -33,7 +33,7 @@ public class BasketController {
     @Secured({"ROLE_CUSTOMER"})
     @PostMapping
     public ResponseEntity<BasketResponseDto> addProductToBasket(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                @Valid @RequestBody BasketAddRequestDto request) {
+                                                                @Valid @RequestBody BasketAddRequestDto request) {
         //장바구니 추가
         BasketResponseDto response = basketService.addProductToBasket(userDetails.getUsername(), request);
 
@@ -43,15 +43,16 @@ public class BasketController {
 
     @Secured({"ROLE_CUSTOMER"})
     @DeleteMapping("/{basketId}")
-    public ResponseEntity<?> removeProductFromBasket(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                     @PathVariable UUID basketId) {
+    public ResponseEntity<BasketResponseDto> removeProductFromBasket(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID basketId) {
         BasketResponseDto response = basketService.removeProductFromBasket(userDetails.getUsername(), basketId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @Secured({"ROLE_CUSTOMER"})
     @GetMapping
-    public ResponseEntity<?> getBaskets(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<List<BasketGetResponseDto>> getBaskets(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         //장바구니 리스트 조회
         List<BasketGetResponseDto> responseDtoList = basketService.getBaskets(userDetails.getUsername());
         //200 응답
@@ -60,8 +61,8 @@ public class BasketController {
 
     @Secured({"ROLE_CUSTOMER"})
     @PutMapping
-    public ResponseEntity<?> updateBasket(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                          @RequestBody BasketUpdateRequestDto request) {
+    public ResponseEntity<BasketResponseDto> updateBasket(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                          @RequestBody BasketUpdateRequestDto request) {
         //장바구니 수정
         BasketResponseDto response = basketService.updateBasket(userDetails.getUsername(), request);
         //200 응답

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/BasketAddRequestDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/BasketAddRequestDto.java
@@ -15,9 +15,9 @@ import lombok.NoArgsConstructor;
 @Builder
 public class BasketAddRequestDto {
     @NotNull
-    private UUID productId; // 음식은 가상의 id로 입력
+    private UUID productId;
     @NotNull
-    private UUID storeId; //원래 음식에 접근해서 점포 정보를 가져오려고 했지만 빠른 연동을 위해 장바구니와 점포를 연동했습니다.
+    private UUID storeId;
     @NotNull
     @Min(value = 1)
     @Max(value = 99)

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/BasketGetResponseDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/BasketGetResponseDto.java
@@ -28,7 +28,7 @@ public class BasketGetResponseDto {
                 .username(basket.getUser().getUsername())
                 .storeId(basket.getStore().getStoreId())
                 .storeName(basket.getStore().getStoreName())
-                .productId(basket.getProductId())
+                .productId(basket.getProduct().getProductId())
                 .quantity(basket.getQuantity())
                 .build();
     }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/BasketGetResponseDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/BasketGetResponseDto.java
@@ -19,6 +19,7 @@ public class BasketGetResponseDto {
     private UUID storeId;
     private String storeName;
     private UUID productId;
+    private String productName;
     private Integer quantity;
 
     public static BasketGetResponseDto fromBasket(Basket basket) {
@@ -29,6 +30,7 @@ public class BasketGetResponseDto {
                 .storeId(basket.getStore().getStoreId())
                 .storeName(basket.getStore().getStoreName())
                 .productId(basket.getProduct().getProductId())
+                .productName(basket.getProduct().getName())
                 .quantity(basket.getQuantity())
                 .build();
     }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/Basket.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/Basket.java
@@ -31,26 +31,28 @@ public class Basket extends BaseEntity {
     @JoinColumn(name = "user_id")
     User user;
 
-    @ManyToOne //원래 음식 fk 만 둬서 점포 접근하려고 했지만 점포가 먼저 생겨 하나 생성했습니다.
+    @ManyToOne
     @JoinColumn(name = "store_id")
     private Store store;
 
-    private UUID productId; // 임시 컬럼
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
 
     @Column(nullable = false)
     private Integer quantity;
 
-    public static Basket ofUserAndOrderProduct(User user, OrderProduct orderProduct) {
+    public static Basket ofUserAndOrderProduct(User user, Product product, OrderProduct orderProduct) {
         return Basket.builder()
-                .productId(orderProduct.getProduct())
+                .product(product)
                 .quantity(orderProduct.getQuantity())
                 .user(user)
                 .build();
     }
 
-    public static Basket ofUserAndStoreAndRequest(User user, Store store, BasketAddRequestDto requestDto) {
+    public static Basket ofUserAndStoreAndRequest(User user, Store store, Product product, BasketAddRequestDto requestDto) {
         return Basket.builder()
-                .productId(requestDto.getProductId())
+                .product(product)
                 .store(store)
                 .quantity(requestDto.getQuantity())
                 .user(user)
@@ -59,14 +61,6 @@ public class Basket extends BaseEntity {
 
     public void updateBasketOfQuantity(Integer quantity) {
         this.quantity = quantity;
-    }
-
-    public static Basket ofUserAndRequest(User user, BasketAddRequestDto requestDto) {
-        return Basket.builder()
-                .productId(requestDto.getProductId())
-                .quantity(requestDto.getQuantity())
-                .user(user)
-                .build();
     }
 
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/OrderProduct.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/entity/OrderProduct.java
@@ -41,7 +41,7 @@ public class OrderProduct extends BaseEntity{
 
     public static OrderProduct ofBasketAndOrder(Basket basket, Order order){
         return OrderProduct.builder()
-                .product(basket.getProductId()) //product가 없기 때문에 임시값 대입
+                //.product(basket.getProductId()) //product가 없기 때문에 임시값 대입
                 .order(order)
                 .quantity(basket.getQuantity())
                 .price(5000) //product가 없기 때문에 임시값 대입

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/BasketExceptionMessage.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/BasketExceptionMessage.java
@@ -9,6 +9,8 @@ public enum BasketExceptionMessage {
     //장바구니
     BASKET_NOT_FOUND("장바구니를 찾을 수 없습니다."),
     BASKET_USER_NOT_EQUALS("장바구니 유저가 아닙니다."),
-    BASKET_COUNT_ZERO("장바구니에 담긴 상품이 없습니다.");
+    BASKET_COUNT_ZERO("장바구니에 담긴 상품이 없습니다."),
+    BASKET_DUPLICATED("장바구니에 담긴 상품입니다."),
+    BASKET_DIFFERENT_STORE("장바구니에 담긴 상품과 다른 지점 상품입니다.");
     private final String message;
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
@@ -94,9 +94,11 @@ public class BasketService {
         //유저 유효성 검사
         User user = userRepository.findById(username)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         //장바구니 유효성 검사
         Basket basket = basketRepository.findById(request.getBasketId()).orElseThrow(() ->
                 new NullPointerException(BasketExceptionMessage.BASKET_NOT_FOUND.getMessage()));
+
         //장바구니 유저와 api 호출 유저 체크
         checkBasketUser(user, basket);
 

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
@@ -82,8 +82,10 @@ public class BasketService {
         // 유저 유효성 검증
         User user = userRepository.findById(username)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         // 유저, 장바구니 join
         List<Basket> basketList = basketRepository.findAllByUser(user);
+
         return basketList.stream().map(BasketGetResponseDto::fromBasket).collect(Collectors.toList());
     }
 

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
@@ -37,7 +37,7 @@ public class BasketService {
                 .orElseThrow(() -> new NullPointerException("점포를 찾을 수 없습니다."));
 
         // 상품이 유효성, 중복 체크
-        Basket basket = Basket.ofUserAndStoreAndRequest(user, store, request);
+        Basket basket = Basket.ofUserAndStoreAndRequest(user, store, null, request);
 
         basket = basketRepository.save(basket);
         return BasketResponseDto.fromBasket(basket);

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
@@ -60,17 +60,21 @@ public class BasketService {
     }
 
 
+    @Transactional
     public BasketResponseDto removeProductFromBasket(String username, UUID basketId) {
         //유저 유효성 검사
         User user = userRepository.findById(username)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         //장바구니 유효성 검사
         Basket basket = basketRepository.findById(basketId).orElseThrow(() ->
                 new NullPointerException(BasketExceptionMessage.BASKET_NOT_FOUND.getMessage()));
+
         //유저와 장바구니 유저 체크
         checkBasketUser(user, basket);
 
         basketRepository.delete(basket);
+
         return BasketResponseDto.fromBasket(basket);
     }
 

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
@@ -141,7 +141,7 @@ public class OrderService {
         //orderProduct 조회 후 basket 저장
         List<OrderProduct> orderProducts = orderProductRepository.findAllByOrder(order);
         for (OrderProduct orderProduct : orderProducts) {
-            Basket basket = Basket.ofUserAndOrderProduct(user, orderProduct);
+            Basket basket = Basket.ofUserAndOrderProduct(user, null,orderProduct); // 수정이 필요
             basketRepository.save(basket);
         }
 

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/BasketControllerTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/BasketControllerTest.java
@@ -101,7 +101,7 @@ class BasketControllerTest {
     }
 
     @Test
-    @DisplayName("장바구니 빼기")
+    @DisplayName("장바구니 빼기 성공")
     @MockUser(role = UserRoleEnum.CUSTOMER)
     void removeProductFromBasket_success() throws Exception {
         //given
@@ -112,10 +112,25 @@ class BasketControllerTest {
         when(basketService.removeProductFromBasket(any(), any())).thenReturn(response);
 
         //then
-        mvc.perform(delete(BASE_URL + "/baskets/{basketId}", basketId.toString())
-                        .with(csrf()))
+        mvc.perform(delete(BASE_URL + "/baskets/{basketId}", basketId.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.basketId").exists());
+    }
+
+    @Test
+    @DisplayName("장바구니 빼기 실패 : 허용하지 않은 권한으로 호출")
+    @MockUser(role = UserRoleEnum.OWNER)
+    void removeProductFromBasket_fail() throws Exception {
+        //given
+        UUID basketId = UUID.randomUUID();
+        BasketResponseDto response = new BasketResponseDto(basketId);
+
+        //when
+        when(basketService.removeProductFromBasket(any(), any())).thenReturn(response);
+
+        //then
+        mvc.perform(delete(BASE_URL + "/baskets/{basketId}", basketId.toString()))
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/BasketControllerTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/controller/BasketControllerTest.java
@@ -134,9 +134,9 @@ class BasketControllerTest {
     }
 
     @Test
-    @DisplayName("장바구니 조회")
+    @DisplayName("장바구니 조회 성공")
     @MockUser(role = UserRoleEnum.CUSTOMER)
-    void getBaskets() throws Exception {
+    void getBaskets_success() throws Exception {
         //given
         UUID basketId = UUID.randomUUID();
         UUID productId = UUID.randomUUID();
@@ -156,6 +156,31 @@ class BasketControllerTest {
         //then
         mvc.perform(get(BASE_URL + "/baskets"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("장바구니 조회 실패 : 허용하지 않은 권한")
+    @MockUser(role = UserRoleEnum.OWNER)
+    void getBaskets_fail() throws Exception {
+        //given
+        UUID basketId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        String storeName = "storeName";
+        Integer quantity = 2;
+        BasketGetResponseDto responseDto = BasketGetResponseDto.builder()
+                .basketId(basketId)
+                .productId(productId)
+                .storeName(storeName)
+                .storeId(storeId)
+                .quantity(quantity)
+                .build();
+        //when
+        when(basketService.getBaskets(any())).thenReturn(List.of(responseDto));
+
+        //then
+        mvc.perform(get(BASE_URL + "/baskets"))
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/BasketServiceTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/BasketServiceTest.java
@@ -275,17 +275,16 @@ class BasketServiceTest {
     void removeProductFromBasket_success() {
         //given
         UUID basketId = UUID.randomUUID();
-        UUID productId = UUID.randomUUID();
         UUID storeId = UUID.randomUUID();
         String username = "user";
-        String storename = "storename";
+        String storeName = "store";
         User user = User.builder()
                 .role(UserRoleEnum.CUSTOMER)
                 .username(username)
                 .build();
         Store store = Store.builder()
                 .storeId(storeId)
-                .storeName(storename)
+                .storeName(storeName)
                 .build();
         Basket basket = Basket.builder()
                 .id(basketId)
@@ -322,9 +321,8 @@ class BasketServiceTest {
         when(basketRepository.findById(any())).thenReturn(Optional.empty());
 
         //when & then
-        Exception exception = assertThrows(NullPointerException.class, () -> {
-            basketService.removeProductFromBasket(username, basketId);
-        });
+        Exception exception = assertThrows(NullPointerException.class,
+                () -> basketService.removeProductFromBasket(username, basketId));
         assertEquals(BasketExceptionMessage.BASKET_NOT_FOUND.getMessage(), exception.getMessage());
     }
 
@@ -335,13 +333,11 @@ class BasketServiceTest {
         UUID basketId = UUID.randomUUID();
         String username = "user";
 
-        //when
         when(userRepository.findById(any())).thenReturn(Optional.empty());
 
         //when & then
-        Exception exception = assertThrows(NullPointerException.class, () -> {
-            basketService.removeProductFromBasket(username, basketId);
-        });
+        Exception exception = assertThrows(NullPointerException.class,
+                () -> basketService.removeProductFromBasket(username, basketId));
         assertEquals(ExceptionMessage.USER_NOT_FOUND.getMessage(), exception.getMessage());
     }
 
@@ -350,11 +346,10 @@ class BasketServiceTest {
     void removeProductFromBasket_fail3() {
         //given
         UUID basketId = UUID.randomUUID();
-        UUID productId = UUID.randomUUID();
         UUID storeId = UUID.randomUUID();
         String username1 = "user1";
         String username2 = "user2";
-        String storename = "storename";
+        String storeName = "store";
         User user1 = User.builder()
                 .role(UserRoleEnum.CUSTOMER)
                 .username(username1)
@@ -365,7 +360,7 @@ class BasketServiceTest {
                 .build();
         Store store = Store.builder()
                 .storeId(storeId)
-                .storeName(storename)
+                .storeName(storeName)
                 .build();
         Basket basket = Basket.builder()
                 .id(basketId)
@@ -378,9 +373,8 @@ class BasketServiceTest {
         given(basketRepository.findById(any())).willReturn(Optional.ofNullable(basket));
 
         //when & then
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            basketService.removeProductFromBasket(username2, basketId);
-        });
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> basketService.removeProductFromBasket(username2, basketId));
         assertEquals(BasketExceptionMessage.BASKET_USER_NOT_EQUALS.getMessage(), exception.getMessage());
     }
 

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/BasketServiceTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/BasketServiceTest.java
@@ -382,12 +382,13 @@ class BasketServiceTest {
     @DisplayName("장바구니 조회 성공")
     void getBaskets() {
         //given
-        String username = "user1";
-        String storeName = "storeName";
+        String username = "user";
+        String storeName = "store";
+        String productName = "product";
+        Integer quantity = 2;
         UUID basketId = UUID.randomUUID();
         UUID productId = UUID.randomUUID();
         UUID storeId = UUID.randomUUID();
-        Integer quantity = 2;
         User user = User.builder()
                 .role(UserRoleEnum.CUSTOMER)
                 .username(username)
@@ -396,10 +397,15 @@ class BasketServiceTest {
                 .storeId(storeId)
                 .storeName(storeName)
                 .build();
+        Product product = Product.builder()
+                .productId(productId)
+                .name(productName)
+                .build();
         Basket basket = Basket.builder()
                 .id(basketId)
                 .store(store)
-                .quantity(2)
+                .product(product)
+                .quantity(quantity)
                 .user(user)
                 .build();
         BasketGetResponseDto responseDto = BasketGetResponseDto.builder()
@@ -427,9 +433,7 @@ class BasketServiceTest {
         given(userRepository.findById(any())).willReturn(Optional.empty());
 
         //when & then
-        Exception exception = assertThrows(NullPointerException.class, () -> {
-            basketService.getBaskets(username);
-        });
+        Exception exception = assertThrows(NullPointerException.class, () -> basketService.getBaskets(username));
         assertEquals(ExceptionMessage.USER_NOT_FOUND.getMessage(), exception.getMessage());
     }
 

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/BasketServiceTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/BasketServiceTest.java
@@ -444,7 +444,6 @@ class BasketServiceTest {
         String username = "user1";
         String storeName = "storeName";
         UUID basketId = UUID.randomUUID();
-        UUID productId = UUID.randomUUID();
         UUID storeId = UUID.randomUUID();
         Integer quantity = 3;
         User user = User.builder()
@@ -475,6 +474,7 @@ class BasketServiceTest {
 
         //then
         Assertions.assertEquals(basketId, response.getBasketId());
+        assert basket != null;
         assertEquals(quantity, basket.getQuantity());
     }
 
@@ -497,9 +497,8 @@ class BasketServiceTest {
         when(basketRepository.findById(any())).thenReturn(Optional.empty());
 
         //when & then
-        Exception exception = assertThrows(NullPointerException.class, () -> {
-            basketService.updateBasket("user1", request);
-        });
+        Exception exception = assertThrows(NullPointerException.class,
+                () -> basketService.updateBasket("user1", request));
         assertEquals(BasketExceptionMessage.BASKET_NOT_FOUND.getMessage(), exception.getMessage());
     }
 
@@ -515,20 +514,19 @@ class BasketServiceTest {
                 .build();
         when(userRepository.findById(any())).thenReturn(Optional.empty());
         //when & then
-        Exception exception = assertThrows(NullPointerException.class, () -> {
-            basketService.updateBasket("user1", request);
-        });
+        Exception exception = assertThrows(NullPointerException.class,
+                () -> basketService.updateBasket("user1", request));
+        assertEquals(ExceptionMessage.USER_NOT_FOUND.getMessage(), exception.getMessage());
     }
 
     @Test
     @DisplayName("장바구니 수정 실패3 : 장바구니 유저와 api 호출한 유저가 일치하지 않는 경우")
     void updateBasket_fail3() {
         //given
-        String basketId = "e623f3c2-4b79-4f3a-b876-9d1b5d47a283";
-        String productId = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+        UUID basketId = UUID.randomUUID();
         Integer quantity = 2;
         BasketUpdateRequestDto request = BasketUpdateRequestDto.builder()
-                .basketId(UUID.fromString(basketId))
+                .basketId(basketId)
                 .quantity(quantity)
                 .build();
         User user = User.builder()
@@ -540,7 +538,7 @@ class BasketServiceTest {
                 .username("user2")
                 .build();
         Basket basket = Basket.builder()
-                .id(UUID.fromString(basketId))
+                .id(basketId)
                 .quantity(quantity)
                 .user(user)
                 .build();
@@ -550,8 +548,6 @@ class BasketServiceTest {
         given(basketRepository.save(any())).willReturn(basket);
 
         //when & then
-        assertThrows(IllegalArgumentException.class, () -> {
-            basketService.updateBasket("user2", request);
-        });
+        assertThrows(IllegalArgumentException.class, () -> basketService.updateBasket("user2", request));
     }
 }

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/BasketServiceTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/BasketServiceTest.java
@@ -55,7 +55,6 @@ class BasketServiceTest {
                 .build();
         Basket basket = Basket.builder()
                 .id(basketId)
-                .productId(productId)
                 .store(store)
                 .quantity(quantity)
                 .build();
@@ -148,7 +147,6 @@ class BasketServiceTest {
                 .build();
         Basket basket = Basket.builder()
                 .id(basketId)
-                .productId(productId)
                 .store(store)
                 .quantity(2)
                 .user(user)
@@ -229,7 +227,6 @@ class BasketServiceTest {
                 .build();
         Basket basket = Basket.builder()
                 .id(basketId)
-                .productId(productId)
                 .store(store)
                 .quantity(2)
                 .user(user1)
@@ -265,7 +262,6 @@ class BasketServiceTest {
                 .build();
         Basket basket = Basket.builder()
                 .id(basketId)
-                .productId(productId)
                 .store(store)
                 .quantity(2)
                 .user(user)
@@ -321,7 +317,6 @@ class BasketServiceTest {
                 .build();
         Basket basket = Basket.builder()
                 .id(basketId)
-                .productId(productId)
                 .store(store)
                 .quantity(2)
                 .user(user)
@@ -406,7 +401,6 @@ class BasketServiceTest {
                 .build();
         Basket basket = Basket.builder()
                 .id(UUID.fromString(basketId))
-                .productId(UUID.fromString(productId))
                 .quantity(quantity)
                 .user(user)
                 .build();

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/OrderServiceTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/OrderServiceTest.java
@@ -65,7 +65,6 @@ class OrderServiceTest {
         Basket basket = Basket.builder()
                 .id(basketId)
                 .user(user)
-                .productId(productId)
                 .quantity(2)
                 .build();
         Store store = Store.builder()
@@ -401,7 +400,6 @@ class OrderServiceTest {
         Basket basket = Basket.builder()
                 .id(basketId)
                 .user(user)
-                .productId(productId)
                 .quantity(2)
                 .build();
         UUID storeId = UUID.randomUUID();


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/basket-api -> main

### 변경 사항
- 장바구니와 음식 도메인 연관관계 매핑했습니다.
- warning 사항 제거했습니다.
- 장바구니 조회 responseDto에 음식관련 정보 필드 추가했습니다.
- 시큐리티 권한 테스트 케이스 추가했습니다.