### PR TITLE
refactor: 주소 기능 리팩토링

### DIFF
--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/AddressController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/AddressController.java
@@ -52,7 +52,7 @@ public class AddressController {
     }
 
     @GetMapping("/")
-    public ResponseEntity<?> getAllAddress(
+    public ResponseEntity<?> getAllAddresses(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @RequestParam("sortBy") String sortBy,

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/AddressController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/AddressController.java
@@ -6,10 +6,10 @@ import com.sparta.blackwhitedeliverydriver.dto.AddressResponseDto;
 import com.sparta.blackwhitedeliverydriver.security.UserDetailsImpl;
 import com.sparta.blackwhitedeliverydriver.service.AddressService;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -52,14 +52,14 @@ public class AddressController {
     }
 
     @GetMapping("/")
-    public ResponseEntity<List<AddressResponseDto>> getAllAddresses(
+    public ResponseEntity<Page<AddressResponseDto>> getAllAddresses(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @RequestParam("sortBy") String sortBy,
             @RequestParam("isAsc") boolean isAsc,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 사용자의 모든 주소를 가져온다
-        List<AddressResponseDto> addressResponseDtos = addressService.getAllAddresses(userDetails.getUsername(), page-1, size, sortBy, isAsc);
+        Page<AddressResponseDto> addressResponseDtos = addressService.getAllAddresses(userDetails.getUsername(), page-1, size, sortBy, isAsc);
 
         // 성공 응답으로 200 OK와 AddressResponseDto 리스트 반환
         return ResponseEntity.status(HttpStatus.OK).body(addressResponseDtos);

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/AddressController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/AddressController.java
@@ -32,7 +32,7 @@ public class AddressController {
     private final AddressService addressService;
 
     @PostMapping("/")
-    public ResponseEntity<?> createAddress(@Valid @RequestBody AddressRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<AddressIdResponseDto> createAddress(@Valid @RequestBody AddressRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 주소 등록 처리
         AddressIdResponseDto addressIdResponseDto = addressService.createAddress(requestDto, userDetails.getUsername());
 
@@ -41,7 +41,7 @@ public class AddressController {
     }
 
     @PutMapping("/{addressId}")
-    public ResponseEntity<?> updateAddress(@Valid @RequestBody AddressRequestDto requestDto,
+    public ResponseEntity<AddressIdResponseDto> updateAddress(@Valid @RequestBody AddressRequestDto requestDto,
                                            @PathVariable UUID addressId,
                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 주소 수정 처리
@@ -52,7 +52,7 @@ public class AddressController {
     }
 
     @GetMapping("/")
-    public ResponseEntity<?> getAllAddresses(
+    public ResponseEntity<List<AddressResponseDto>> getAllAddresses(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @RequestParam("sortBy") String sortBy,
@@ -66,7 +66,7 @@ public class AddressController {
     }
 
     @GetMapping("/current")
-    public ResponseEntity<?> getCurrentAddress(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<AddressResponseDto> getCurrentAddress(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 사용자의 현재(기본) 배송지를 가져온다
         AddressResponseDto responseDto = addressService.getCurrentAddress(userDetails.getUsername());
 
@@ -75,7 +75,7 @@ public class AddressController {
     }
 
     @PutMapping("/{addressId}/current")
-    public ResponseEntity<?> setCurrentAddress(@PathVariable UUID addressId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<AddressIdResponseDto> setCurrentAddress(@PathVariable UUID addressId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 사용자의 현재(기본) 배송지를 지정한다
         AddressIdResponseDto addressIdResponseDto = addressService.setCurrentAddress(addressId, userDetails.getUsername());
 
@@ -84,7 +84,7 @@ public class AddressController {
     }
 
     @DeleteMapping("/{addressId}")
-    public ResponseEntity<?> deleteAddress(@PathVariable UUID addressId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<AddressIdResponseDto> deleteAddress(@PathVariable UUID addressId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 주소 삭제 처리(soft-delete)
         AddressIdResponseDto addressIdResponseDto = addressService.deleteAddress(addressId, userDetails.getUsername());
 

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/AddressController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/AddressController.java
@@ -34,7 +34,7 @@ public class AddressController {
     @PostMapping("/")
     public ResponseEntity<?> createAddress(@Valid @RequestBody AddressRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 주소 등록 처리
-        AddressIdResponseDto addressIdResponseDto = addressService.createAddress(requestDto, userDetails.getUser());
+        AddressIdResponseDto addressIdResponseDto = addressService.createAddress(requestDto, userDetails.getUsername());
 
         // 성공 응답으로 201 Created와 addressIdResponseDto 반환
         return ResponseEntity.status(HttpStatus.CREATED).body(addressIdResponseDto);
@@ -45,7 +45,7 @@ public class AddressController {
                                            @PathVariable UUID addressId,
                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 주소 수정 처리
-        AddressIdResponseDto addressIdResponseDto = addressService.updateAddress(requestDto, addressId, userDetails.getUser());
+        AddressIdResponseDto addressIdResponseDto = addressService.updateAddress(requestDto, addressId, userDetails.getUsername());
 
         // 성공 응답으로 200 OK와 addressIdResponseDto 반환
         return ResponseEntity.status(HttpStatus.OK).body(addressIdResponseDto);
@@ -59,7 +59,7 @@ public class AddressController {
             @RequestParam("isAsc") boolean isAsc,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 사용자의 모든 주소를 가져온다
-        List<AddressResponseDto> addressResponseDtos = addressService.getAllAddresses(userDetails.getUser(), page-1, size, sortBy, isAsc);
+        List<AddressResponseDto> addressResponseDtos = addressService.getAllAddresses(userDetails.getUsername(), page-1, size, sortBy, isAsc);
 
         // 성공 응답으로 200 OK와 AddressResponseDto 리스트 반환
         return ResponseEntity.status(HttpStatus.OK).body(addressResponseDtos);
@@ -77,7 +77,7 @@ public class AddressController {
     @PutMapping("/{addressId}/current")
     public ResponseEntity<?> setCurrentAddress(@PathVariable UUID addressId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 사용자의 현재(기본) 배송지를 지정한다
-        AddressIdResponseDto addressIdResponseDto = addressService.setCurrentAddress(addressId, userDetails.getUser());
+        AddressIdResponseDto addressIdResponseDto = addressService.setCurrentAddress(addressId, userDetails.getUsername());
 
         // 성공 응답으로 200 OK와 addressIdResponseDto 반환
         return ResponseEntity.status(HttpStatus.OK).body(addressIdResponseDto);
@@ -86,7 +86,7 @@ public class AddressController {
     @DeleteMapping("/{addressId}")
     public ResponseEntity<?> deleteAddress(@PathVariable UUID addressId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 주소 삭제 처리(soft-delete)
-        AddressIdResponseDto addressIdResponseDto = addressService.deleteAddress(addressId, userDetails.getUser());
+        AddressIdResponseDto addressIdResponseDto = addressService.deleteAddress(addressId, userDetails.getUsername());
 
         // 성공 응답으로 200 OK와 addressIdResponseDto 반환
         return ResponseEntity.status(HttpStatus.OK).body(addressIdResponseDto);

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/AddressRepository.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/AddressRepository.java
@@ -2,7 +2,6 @@ package com.sparta.blackwhitedeliverydriver.repository;
 
 import com.sparta.blackwhitedeliverydriver.entity.Address;
 import com.sparta.blackwhitedeliverydriver.entity.User;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +12,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, UUID> {
-    @Query("SELECT a FROM Address a WHERE a.user = :user AND a.deletedBy IS NULL AND a.deletedDate IS NULL")
-    Page<Address> findAllByUserAndNotDeleted(@Param("user") User user, Pageable pageable);
+    Page<Address> findAllByUserAndDeletedByIsNullAndDeletedDateIsNull(User user, Pageable pageable);
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
@@ -10,8 +10,6 @@ import com.sparta.blackwhitedeliverydriver.repository.AddressRepository;
 import com.sparta.blackwhitedeliverydriver.repository.UserRepository;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -61,7 +59,7 @@ public class AddressService {
         return new AddressIdResponseDto(address.getId());
     }
 
-    public List<AddressResponseDto> getAllAddresses(String username, int page, int size, String sortBy, boolean isAsc) {
+    public Page<AddressResponseDto> getAllAddresses(String username, int page, int size, String sortBy, boolean isAsc) {
         User user = userRepository.findById(username)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
 
@@ -76,13 +74,8 @@ public class AddressService {
 
         // 페이징이 적용된 Address 리스트를 가져온다
         Page<Address> addressPage = addressRepository.findAllByUserAndDeletedByIsNullAndDeletedDateIsNull(user, pageable);
-        List<AddressResponseDto> addressResponseDtos = new ArrayList<>();
 
-        for (Address address : addressPage) {
-            addressResponseDtos.add(AddressResponseDto.from(address));
-        }
-
-        return addressResponseDtos;
+        return addressPage.map(AddressResponseDto::from);
     }
 
     public AddressResponseDto getCurrentAddress(String username) {

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
@@ -31,7 +31,10 @@ public class AddressService {
     private final UserRepository userRepository;
 
     @Transactional
-    public AddressIdResponseDto createAddress(@Valid AddressRequestDto requestDto, User user) {
+    public AddressIdResponseDto createAddress(@Valid AddressRequestDto requestDto, String username) {
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         Address address = Address.from(requestDto, user);
         addressRepository.save(address);
 
@@ -39,7 +42,10 @@ public class AddressService {
     }
 
     @Transactional
-    public AddressIdResponseDto updateAddress(@Valid AddressRequestDto requestDto, UUID addressId, User user) {
+    public AddressIdResponseDto updateAddress(@Valid AddressRequestDto requestDto, UUID addressId, String username) {
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         Address address = addressRepository.findById(addressId)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.ADDRESS_NOT_FOUND.getMessage()));
 
@@ -55,7 +61,10 @@ public class AddressService {
         return new AddressIdResponseDto(address.getId());
     }
 
-    public List<AddressResponseDto> getAllAddresses(User user, int page, int size, String sortBy, boolean isAsc) {
+    public List<AddressResponseDto> getAllAddresses(String username, int page, int size, String sortBy, boolean isAsc) {
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         if (size != 10 && size != 30 && size != 50) {
             size = 10;
         }
@@ -89,7 +98,10 @@ public class AddressService {
     }
 
     @Transactional
-    public AddressIdResponseDto setCurrentAddress(UUID addressId, User user) {
+    public AddressIdResponseDto setCurrentAddress(UUID addressId, String username) {
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         Address address = addressRepository.findById(addressId)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.ADDRESS_NOT_FOUND.getMessage()));
 
@@ -104,7 +116,10 @@ public class AddressService {
     }
 
     @Transactional
-    public AddressIdResponseDto deleteAddress(UUID addressId, User user) {
+    public AddressIdResponseDto deleteAddress(UUID addressId, String username) {
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         Address address = addressRepository.findById(addressId)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.ADDRESS_NOT_FOUND.getMessage()));
 

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
@@ -66,7 +66,7 @@ public class AddressService {
         Pageable pageable = PageRequest.of(page, size, sort);
 
         // 페이징이 적용된 Address 리스트를 가져온다
-        Page<Address> addressPage = addressRepository.findAllByUserAndNotDeleted(user, pageable);
+        Page<Address> addressPage = addressRepository.findAllByUserAndDeletedByIsNullAndDeletedDateIsNull(user, pageable);
         List<AddressResponseDto> addressResponseDtos = new ArrayList<>();
 
         for (Address address : addressPage) {


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/address-api -> main

### 변경 사항
- AddressRepository의 삭제되지 않은 주소를 가져오는 메서드를 ``@Qurey``를 활용하는 방식에서 메서드 네이밍으로 처리하도록 변경
- userDetails 파라미터로 User 객체를 넘기던 부분을 username을 넘기도록 변경
- 컨트롤러 와일드카드 제거
- 주소 리스트 조회에서 기존의 List를 리턴하던 것을 Page를 리턴하도록 변경