### PR TITLE
refactor: StoreResponseDto에 평균 평점 필드 추가

### DIFF
--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/StoreResponseDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/StoreResponseDto.java
@@ -28,6 +28,7 @@ public class StoreResponseDto {
     private String detailAddr;
     private String storeIntro;
     private String category;
+    private double avgRating;
 
     public static StoreResponseDto from(Store store, String categoryNames) {
         return StoreResponseDto.builder()
@@ -45,6 +46,7 @@ public class StoreResponseDto {
                 .detailAddr(store.getDetailAddr())
                 .storeIntro(store.getStoreIntro())
                 .category(categoryNames)
+                .avgRating((double)store.getRating() / store.getReviewCnt())
                 .build();
     }
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/{도메인}-api -> main

### 변경 사항
- StoreResponseDto에 평균 평점 필드 추가
- 평균 평점 계산은 정적 팩토리 메서드를 통해 ResponseDto가 생성될 때 Store의 평점 합계와 리뷰수를 가져와 수행함