### PR TITLE
refactor: 배송지 삭제 시 현재(기본) 배송지 제거 로직 추가 및 생성자 검증 메서드 분리

### DIFF
--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
@@ -4,6 +4,7 @@ import com.sparta.blackwhitedeliverydriver.dto.AddressIdResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.AddressRequestDto;
 import com.sparta.blackwhitedeliverydriver.dto.AddressResponseDto;
 import com.sparta.blackwhitedeliverydriver.entity.Address;
+import com.sparta.blackwhitedeliverydriver.entity.Review;
 import com.sparta.blackwhitedeliverydriver.entity.User;
 import com.sparta.blackwhitedeliverydriver.exception.ExceptionMessage;
 import com.sparta.blackwhitedeliverydriver.repository.AddressRepository;
@@ -48,10 +49,7 @@ public class AddressService {
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.ADDRESS_NOT_FOUND.getMessage()));
 
         checkDeletedAddress(address);
-
-        if (!address.getUser().getUsername().equals(user.getUsername())) {
-            throw new AccessDeniedException(ExceptionMessage.NOT_ALLOWED_API.getMessage());
-        }
+        checkCreatedBy(address, user.getUsername());
 
         address.update(requestDto);
         addressRepository.save(address);
@@ -98,9 +96,7 @@ public class AddressService {
         Address address = addressRepository.findById(addressId)
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.ADDRESS_NOT_FOUND.getMessage()));
 
-        if (!address.getUser().getUsername().equals(user.getUsername())) {
-            throw new AccessDeniedException(ExceptionMessage.NOT_ALLOWED_API.getMessage());
-        }
+        checkCreatedBy(address, user.getUsername());
 
         user.updateCurrentAddress(address);
         userRepository.save(user);
@@ -117,10 +113,7 @@ public class AddressService {
                 .orElseThrow(() -> new NullPointerException(ExceptionMessage.ADDRESS_NOT_FOUND.getMessage()));
 
         checkDeletedAddress(address);
-
-        if (!address.getUser().getUsername().equals(user.getUsername())) {
-            throw new AccessDeniedException(ExceptionMessage.NOT_ALLOWED_API.getMessage());
-        }
+        checkCreatedBy(address, user.getUsername());
 
         // 삭제하는 배송지가 사용자의 현재(기본)배송지라면 현재(기본)배송지를 null로 처리
         if (user.getCurrentAddress().equals(address)) {
@@ -146,4 +139,11 @@ public class AddressService {
             throw new IllegalArgumentException(ExceptionMessage.CURRNET_ADDRESS_NOT_FOUND.getMessage());
         }
     }
+
+    private void checkCreatedBy(Address address, String username) {
+        if (!address.getCreatedBy().equals(username)) {
+            throw new AccessDeniedException(ExceptionMessage.NOT_ALLOWED_API.getMessage());
+        }
+    }
+
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/AddressService.java
@@ -122,6 +122,11 @@ public class AddressService {
             throw new AccessDeniedException(ExceptionMessage.NOT_ALLOWED_API.getMessage());
         }
 
+        // 삭제하는 배송지가 사용자의 현재(기본)배송지라면 현재(기본)배송지를 null로 처리
+        if (user.getCurrentAddress().equals(address)) {
+            user.updateCurrentAddress(null);
+        }
+
         address.setDeletedBy(user.getUsername());
         address.setDeletedDate(LocalDateTime.now());
 


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/address-api -> main

### 변경 사항
- 배송지 삭제 시 현재(기본)배송지를 null로 처리하도록 변경
- 기존 Address의 외래키(username)를 확인하는 로직을 메서드로 분리하고 생성자(CreatedBy)를 확인해서 검증하도록 변경