### PR TITLE
feat : pay 검색 기능 구현 및 조회 페이징, 환불 로직 처리 적용

### DIFF
--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/PayController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/PayController.java
@@ -92,6 +92,7 @@ public class PayController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @Secured({"ROLE_MASTER", "ROLE_MANAGER"})
     @GetMapping("/search")
     public ResponseEntity<Page<PayGetResponseDto>> searchPayments(
             @RequestParam("storeName") String storeName,

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/PayController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/PayController.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -68,9 +69,14 @@ public class PayController {
 
     @Secured({"ROLE_CUSTOMER", "ROLE_MASTER", "ROLE_MANAGER"})
     @GetMapping
-    public ResponseEntity<List<PayGetResponseDto>> getPays(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<Page<PayGetResponseDto>> getPays(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                           @RequestParam("page") int page,
+                                                           @RequestParam("size") int size,
+                                                           @RequestParam("sortBy") String sortBy,
+                                                           @RequestParam("isAsc") boolean isAsc) {
         //pay 목록 조회
-        List<PayGetResponseDto> responses = payService.getPays(userDetails.getUsername());
+        Page<PayGetResponseDto> responses = payService.getPays(userDetails.getUsername(), page - 1, size, sortBy,
+                isAsc);
 
         //200 반환
         return ResponseEntity.status(HttpStatus.OK).body(responses);

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/PayController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/PayController.java
@@ -9,6 +9,7 @@ import com.sparta.blackwhitedeliverydriver.dto.PayRequestDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayReadyResponseDto;
 import com.sparta.blackwhitedeliverydriver.security.UserDetailsImpl;
 import com.sparta.blackwhitedeliverydriver.service.PayService;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -36,8 +37,7 @@ public class PayController {
     @Secured({"ROLE_CUSTOMER"})
     @PostMapping("/ready")
     public ResponseEntity<PayReadyResponseDto> readyToPay(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                          @RequestBody PayRequestDto request) {
-        log.info("user : {}", userDetails.getUser().getUsername());
+                                                          @RequestBody @Valid PayRequestDto request) {
         //결제 준비
         PayReadyResponseDto response = payService.readyToPay(userDetails.getUsername(), request);
         //201 반환
@@ -49,15 +49,16 @@ public class PayController {
     public ResponseEntity<PayApproveResponseDto> afterPay(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                           @RequestParam("pg_token") String pgToken,
                                                           @RequestParam("tid") String tid) {
-        log.info("{}", tid);
+        //결제 승인
         PayApproveResponseDto response = payService.approvePay(userDetails.getUsername(), pgToken, tid);
+        //200 반환
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @Secured({"ROLE_CUSTOMER"})
     @PostMapping("/refund")
     public ResponseEntity<PayRefundResponseDto> refundPay(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                          @RequestBody PayRefundRequestDto request) {
+                                                          @RequestBody @Valid PayRefundRequestDto request) {
         //환불
         PayRefundResponseDto response = payService.refundPayment(userDetails.getUsername(), request);
 

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/PayController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/PayController.java
@@ -3,14 +3,13 @@ package com.sparta.blackwhitedeliverydriver.controller;
 import com.sparta.blackwhitedeliverydriver.dto.PayApproveResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayGetDetailResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayGetResponseDto;
+import com.sparta.blackwhitedeliverydriver.dto.PayReadyResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayRefundRequestDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayRefundResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayRequestDto;
-import com.sparta.blackwhitedeliverydriver.dto.PayReadyResponseDto;
 import com.sparta.blackwhitedeliverydriver.security.UserDetailsImpl;
 import com.sparta.blackwhitedeliverydriver.service.PayService;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -91,5 +90,19 @@ public class PayController {
 
         //200 반환
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<PayGetResponseDto>> searchPayments(
+            @RequestParam("storeName") String storeName,
+            @RequestParam("page") int page,
+            @RequestParam("size") int size,
+            @RequestParam("sortBy") String sortBy,
+            @RequestParam("isAsc") boolean isAsc) {
+
+        Page<PayGetResponseDto> response = payService.searchPaymentsByStoreName(storeName, page, size, sortBy,
+                isAsc);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/PayRefundRequestDto.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/dto/PayRefundRequestDto.java
@@ -1,5 +1,6 @@
 package com.sparta.blackwhitedeliverydriver.dto;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,5 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PayRefundRequestDto {
+    @NotNull
     private UUID orderId;
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/PayExceptionMessage.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/PayExceptionMessage.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PayExceptionMessage {
-    PAY_NOT_FOUND("주문 내역을 찾을 수 없습니다.");
+    PAY_NOT_FOUND("주문 내역을 찾을 수 없습니다."),
+    PAY_OFFLINE_TYPE("오프라인 결제 주문 건으로 온라인 결제를 할 수 없습니다.");
     private final String message;
 }
 

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/PayExceptionMessage.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/exception/PayExceptionMessage.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PayExceptionMessage {
     PAY_NOT_FOUND("주문 내역을 찾을 수 없습니다."),
-    PAY_OFFLINE_TYPE("오프라인 결제 주문 건으로 온라인 결제를 할 수 없습니다.");
+    PAY_OFFLINE_TYPE("오프라인 결제 주문 건으로 온라인 결제를 할 수 없습니다."),
+    PAY_UNABLE("환불를 할 수 없습니다."),
+    PAY_REFUND_TIME_EXCEEDED("결제 시간 5분이 초과되어 환불를 할 수 없습니다.");
     private final String message;
 }
 

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/PayRepository.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/PayRepository.java
@@ -20,4 +20,7 @@ public interface PayRepository extends JpaRepository<Pay, UUID> {
 
     @Query("select p from  Pay p where p.order.user = :user")
     Page<Pay> findAllByUser(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT p FROM Pay p WHERE p.order.store.storeName LIKE %:storeName%")
+    Page<Pay> findByStoreNameContaining(@Param("storeName") String storeName, Pageable pageable);
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/PayRepository.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/PayRepository.java
@@ -2,9 +2,12 @@ package com.sparta.blackwhitedeliverydriver.repository;
 
 import com.sparta.blackwhitedeliverydriver.entity.Order;
 import com.sparta.blackwhitedeliverydriver.entity.Pay;
+import com.sparta.blackwhitedeliverydriver.entity.User;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +17,7 @@ public interface PayRepository extends JpaRepository<Pay, UUID> {
 
     @Query("select p from  Pay p where p.order.user.username = :username")
     List<Pay> findAllByUser(@Param("username") String username);
+
+    @Query("select p from  Pay p where p.order.user = :user")
+    Page<Pay> findAllByUser(@Param("user") User user, Pageable pageable);
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/OrderService.java
@@ -45,6 +45,8 @@ public class OrderService {
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
 
+    private final PayService payService;
+
     @Transactional
     public OrderResponseDto createOrder(String username, OrderAddRequestDto request) {
         //유저 유효성 검사
@@ -197,6 +199,11 @@ public class OrderService {
 
         //주문의 점포 주인과 유저 체크
         checkStoreOwnerEquals(order.getStore(), user);
+
+        //점포 주인이 거절하면 환불
+        if(request.getStatus().equals(OrderStatusEnum.REJECTED)){
+            payService.refundPaymentByReject(order);
+        }
 
         order.updateStatus(request.getStatus());
         return new OrderResponseDto(order.getId());

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/PayService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/PayService.java
@@ -1,25 +1,24 @@
 package com.sparta.blackwhitedeliverydriver.service;
 
-import com.sparta.blackwhitedeliverydriver.dto.PayGetDetailResponseDto;
-import com.sparta.blackwhitedeliverydriver.dto.PayGetResponseDto;
-import com.sparta.blackwhitedeliverydriver.dto.PayRefundRequestDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayApproveResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayCancelResponseDto;
+import com.sparta.blackwhitedeliverydriver.dto.PayGetDetailResponseDto;
+import com.sparta.blackwhitedeliverydriver.dto.PayGetResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayReadyResponseDto;
+import com.sparta.blackwhitedeliverydriver.dto.PayRefundRequestDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayRefundResponseDto;
 import com.sparta.blackwhitedeliverydriver.dto.PayRequestDto;
 import com.sparta.blackwhitedeliverydriver.entity.Order;
 import com.sparta.blackwhitedeliverydriver.entity.OrderProduct;
 import com.sparta.blackwhitedeliverydriver.entity.OrderStatusEnum;
+import com.sparta.blackwhitedeliverydriver.entity.OrderTypeEnum;
 import com.sparta.blackwhitedeliverydriver.entity.Pay;
 import com.sparta.blackwhitedeliverydriver.entity.PayStatusEnum;
-import com.sparta.blackwhitedeliverydriver.entity.Store;
 import com.sparta.blackwhitedeliverydriver.entity.User;
 import com.sparta.blackwhitedeliverydriver.entity.UserRoleEnum;
 import com.sparta.blackwhitedeliverydriver.exception.ExceptionMessage;
 import com.sparta.blackwhitedeliverydriver.exception.OrderExceptionMessage;
 import com.sparta.blackwhitedeliverydriver.exception.PayExceptionMessage;
-import com.sparta.blackwhitedeliverydriver.exception.StoreExceptionMessage;
 import com.sparta.blackwhitedeliverydriver.repository.OrderProductRepository;
 import com.sparta.blackwhitedeliverydriver.repository.OrderRepository;
 import com.sparta.blackwhitedeliverydriver.repository.PayRepository;
@@ -68,6 +67,9 @@ public class PayService {
 
         //주문 상태 체크
         checkOrderStatus(order);
+
+        //주문 타입 체크 - 대면인 경우에는 오프라인 계산
+        checkOrderType(order);
 
         //파라미터와 헤더 설정
         Map<String, String> parameters = payUtil.getReadyPayParameters(user, order);
@@ -215,12 +217,6 @@ public class PayService {
         }
     }
 
-    private void checkDeletedStore(Store store) {
-        if (store.getDeletedDate() != null || store.getDeletedBy() != null) {
-            throw new IllegalArgumentException(StoreExceptionMessage.STORE_NOT_FOUND.getMessage());
-        }
-    }
-
     private void checkDeletedOrder(Order order) {
         if (order.getDeletedDate() != null || order.getDeletedBy() != null) {
             throw new IllegalArgumentException(OrderExceptionMessage.ORDER_NOT_FOUND.getMessage());
@@ -230,6 +226,12 @@ public class PayService {
     private void checkDeletedPay(Pay pay) {
         if (pay.getDeletedDate() != null || pay.getDeletedBy() != null) {
             throw new IllegalArgumentException(PayExceptionMessage.PAY_NOT_FOUND.getMessage());
+        }
+    }
+
+    private void checkOrderType(Order order) {
+        if(order.getType().equals(OrderTypeEnum.OFFLINE)){
+            throw new IllegalArgumentException(PayExceptionMessage.PAY_OFFLINE_TYPE.getMessage());
         }
     }
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/PayService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/PayService.java
@@ -143,7 +143,7 @@ public class PayService {
                 .orElseThrow(() -> new NullPointerException(PayExceptionMessage.PAY_NOT_FOUND.getMessage()));
         checkDeletedPay(pay);
 
-        // **Pay 생성 시간이 5분 이내인지 확인**
+        //Pay 생성 시간이 5분 이내인지 확인
         checkPayWithinFiveMinutes(pay);
 
         //100% 환불로 일단 구현
@@ -214,6 +214,22 @@ public class PayService {
         }
 
         return pays.map(PayGetResponseDto::fromPay);
+    }
+
+    public Page<PayGetResponseDto> searchPaymentsByStoreName(String storeName, int page, int size, String sortBy, boolean isAsc) {
+        // 정렬 및 페이징 정보 생성
+        if (size != 10 && size != 30 && size != 50) {
+            size = 10;
+        }
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        // storeName으로 Pay 검색
+        Page<Pay> payments = payRepository.findByStoreNameContaining(storeName, pageable);
+
+        // Pay 데이터를 DTO로 변환하여 반환
+        return payments.map(PayGetResponseDto::fromPay);
     }
 
     private void checkOrderUser(Order order, User user) {

--- a/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/OrderServiceTest.java
+++ b/blackWhiteDeliveryDriver/src/test/java/com/sparta/blackwhitedeliverydriver/service/OrderServiceTest.java
@@ -46,11 +46,12 @@ class OrderServiceTest {
     OrderProductRepository orderProductRepository = mock(OrderProductRepository.class);
     UserRepository userRepository = mock(UserRepository.class);
     StoreRepository storeRepository = mock(StoreRepository.class);
+    PayService payService = mock(PayService.class);
 
     @BeforeEach
     public void setUp() {
         orderService = new OrderService(basketRepository, orderRepository, orderProductRepository, userRepository,
-                storeRepository);
+                storeRepository, payService);
     }
 
     @Test


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/pay-api -> main

### 변경 사항
- 온라인 주문일 경우에 카카오페이 결제를 할 수 있도록 처리 (대면 주문은 오프라인으로 결제)
- pay 결제 조회 페이징 적용
- 5분 이내의 결제건에 대해서만 환불할 수 있도록 로직 처리
- 점포 이름으로 결제 검색 기능 구현 (어드민 권한만 사용 가능)