### PR TITLE
fix : 장바구니 검색 api 서비스 로직 수정

### DIFF
--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/BasketController.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/controller/BasketController.java
@@ -7,7 +7,6 @@ import com.sparta.blackwhitedeliverydriver.dto.BasketUpdateRequestDto;
 import com.sparta.blackwhitedeliverydriver.security.UserDetailsImpl;
 import com.sparta.blackwhitedeliverydriver.service.BasketService;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -44,7 +43,7 @@ public class BasketController {
     }
 
     @Secured({"ROLE_CUSTOMER"})
-    @DeleteMapping("/{basketId}")
+    @DeleteMapping("/{basketId}")//테스트 완료
     public ResponseEntity<BasketResponseDto> removeProductFromBasket(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable UUID basketId) {
@@ -77,15 +76,17 @@ public class BasketController {
     }
 
     @Secured({"ROLE_CUSTOMER"})
-    @GetMapping("/search")
+    @GetMapping("/search")//테스트 완료
     public ResponseEntity<Page<BasketGetResponseDto>> searchBaskets(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam("productName") String productName,
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @RequestParam("sortBy") String sortBy,
             @RequestParam("isAsc") boolean isAsc) {
 
-        Page<BasketGetResponseDto> baskets = basketService.searchBasketsByProductName(productName, page, size, sortBy, isAsc);
+        Page<BasketGetResponseDto> baskets = basketService.searchBasketsByProductName(userDetails.getUsername(),
+                productName, page, size, sortBy, isAsc);
         return ResponseEntity.ok(baskets);
     }
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/BasketRepository.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/repository/BasketRepository.java
@@ -19,6 +19,6 @@ public interface BasketRepository extends JpaRepository<Basket, UUID> {
     @Query("SELECT b FROM Basket b WHERE b.user = :user AND b.deletedDate IS NULL")
     Page<Basket> findAllByUserAndNotDeleted(User user, Pageable pageable);
 
-    @Query("SELECT b FROM Basket b WHERE b.product.name LIKE %:productName% AND b.deletedDate IS NULL")
-    Page<Basket> findByProductNameContainingAndNotDeleted(@Param("productName") String productName, Pageable pageable);
+    @Query("SELECT b FROM Basket b WHERE b.product.name LIKE %:productName% AND b.user = :user AND b.deletedDate IS NULL")
+    Page<Basket> findByProductNameContainingAndUserAndNotDeleted(@Param("productName") String productName, User user, Pageable pageable);
 }

--- a/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
+++ b/blackWhiteDeliveryDriver/src/main/java/com/sparta/blackwhitedeliverydriver/service/BasketService.java
@@ -130,7 +130,12 @@ public class BasketService {
         return BasketResponseDto.fromBasket(basket);
     }
 
-    public Page<BasketGetResponseDto> searchBasketsByProductName(String productName, int page, int size, String sortBy, boolean isAsc) {
+    public Page<BasketGetResponseDto> searchBasketsByProductName(String username, String productName, int page,
+                                                                 int size, String sortBy, boolean isAsc) {
+        //유저 유효성 검사
+        User user = userRepository.findById(username)
+                .orElseThrow(() -> new NullPointerException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+        checkDeletedUser(user);
         // 페이징과 정렬 정보 생성
         //페이징
         if (size != 10 && size != 30 && size != 50) {
@@ -141,7 +146,7 @@ public class BasketService {
         Pageable pageable = PageRequest.of(page, size, sort);
 
         // 데이터 조회 및 변환
-        Page<Basket> baskets = basketRepository.findByProductNameContainingAndNotDeleted(productName, pageable);
+        Page<Basket> baskets = basketRepository.findByProductNameContainingAndUserAndNotDeleted(productName, user, pageable);
         return baskets.map(BasketGetResponseDto::fromBasket);
     }
 


### PR DESCRIPTION
- 자신의 장바구니가 아닌 경우 검색이 안되도록 쿼리 수정

### PR 타입
- [ ] 기능 추가
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/{도메인}-api -> main

### 변경 사항
- 장바구니 검색 api 서비스 로직 수정
- basketRepository 검색 쿼리 수정